### PR TITLE
Added support for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
   - "pypy3"
 # command to install dependencies

--- a/scripts/html_lint.py
+++ b/scripts/html_lint.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2014 Deezer (http://www.deezer.com)
+# Copyright 2015 Sebastian Kreft
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,7 +81,7 @@ _DISABLE_MAP = {
 }
 
 
-__VERSION__ = '0.1.8'
+__VERSION__ = '0.2.0'
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='html-linter',
-    version='0.1.9',
+    version='0.2.0',
     description='Lints an HTML5 file using Google\'s style guide',
     long_description=open('README.rst').read(),
     author='Sebastian Kreft',
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
It replaces the use of attrfind in favor of attrfind_tolerant, as
the former was removed in python 3.5.

Fixes deezer/html-linter#8.
