### PR TITLE
Support multi-file input

### DIFF
--- a/scripts/html_lint.py
+++ b/scripts/html_lint.py
@@ -25,7 +25,7 @@ https://github.com/kangax/html-minifier.
 This software is released under the Apache License. Copyright Deezer 2014.
 
 Usage:
-  html5_lint.py [--disable=DISABLE] FILENAME
+  html5_lint.py [--disable=DISABLE] FILENAME...
   html5_lint.py (-h | --help)
   html5_lint.py --version
 
@@ -47,74 +47,19 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import codecs
-import io
 import sys
 
 import docopt
 
 import html_linter
-import template_remover
-
-_DISABLE_MAP = {
-    'doctype': html_linter.DocumentTypeMessage,
-    'entities': html_linter.EntityReferenceMessage,
-    'trailing_whitespace': html_linter.TrailingWhitespaceMessage,
-    'tabs': html_linter.TabMessage,
-    'charset': html_linter.CharsetMessage,
-    'void_element': html_linter.VoidElementMessage,
-    'optional_tag': html_linter.OptionalTagMessage,
-    'type_attribute': html_linter.TypeAttributeMessage,
-    'concerns_separation': html_linter.ConcernsSeparationMessage,
-    'protocol': html_linter.ProtocolMessage,
-    'names': html_linter.NameMessage,
-    'capitalization': html_linter.CapitalizationMessage,
-    'quotation': html_linter.QuotationMessage,
-    'indentation': html_linter.IndentationMessage,
-    'formatting': html_linter.FormattingMessage,
-    'boolean_attribute': html_linter.BooleanAttributeMessage,
-    'invalid_attribute': html_linter.InvalidAttributeMessage,
-    'void_zero': html_linter.VoidZeroMessage,
-    'invalid_handler':  html_linter.InvalidHandlerMessage,
-    'http_equiv':  html_linter.HTTPEquivMessage,
-    'extra_whitespace': html_linter.ExtraWhitespaceMessage,
-}
 
 
 __VERSION__ = '0.2.0'
 
 
-def main():
-    """Entry point for the HTML5 Linter."""
-
-    # Wrap sys stdout for python 2, so print can understand unicode.
-    if sys.version_info[0] < 3:
-        sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
-
+if __name__ == '__main__':
     options = docopt.docopt(__doc__,
                             help=True,
                             version='html5_lint v%s' % __VERSION__)
 
-    disable_str = options['--disable'] or ''
-    disable = disable_str.split(',')
-
-    invalid_disable = set(disable) - set(_DISABLE_MAP.keys()) - set(('',))
-    if invalid_disable:
-        sys.stderr.write(
-            'Invalid --disable arguments: %s\n\n' % ', '.join(invalid_disable))
-        sys.stderr.write(__doc__)
-        return 1
-
-    exclude = [_DISABLE_MAP[d] for d in disable if d in _DISABLE_MAP]
-    clean_html = template_remover.clean(io.open(options['FILENAME']).read())
-    results = html_linter.lint(clean_html, exclude=exclude)
-
-    if results:
-        print(results)
-        return 2
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(html_linter.main(options))

--- a/test/data/more_invalid.html
+++ b/test/data/more_invalid.html
@@ -1,0 +1,2 @@
+<!-- Created to test multiple inputs-->
+<br/>

--- a/test/test_html_linter.py
+++ b/test/test_html_linter.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import io
 import os
+import sys
 import unittest
 
 import html_linter
@@ -568,6 +569,42 @@ class TestHTML5LinterFunction(unittest.TestCase):
 
     def test_valid(self):
         self.assertEquals('', html_linter.lint(self.valid_html))
+
+
+class TestHTML5LinterMain(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = 'test/data/{}'
+        cls.valid = path.format('valid.html')
+        cls.invalid = path.format('invalid.html')
+        cls.more_invalid = path.format('more_invalid.html')
+
+    @staticmethod
+    def call_main(**kwargs):
+        exit_code = html_linter.main(kwargs)
+        return sys.stdout.getvalue().strip().splitlines(), exit_code
+
+    def test_valid(self):
+        files = [self.valid]
+        output, exit_code = self.call_main(FILENAME=files)
+        self.assertEquals(0, len(output))
+        self.assertEquals(exit_code, 0)
+
+    def test_invalid(self):
+        files = [self.invalid]
+        output, exit_code = self.call_main(FILENAME=files)
+        self.assertEquals(49, len(output))
+        self.assertEquals(exit_code, 2)
+
+    def test_multiple(self):
+        files = [self.valid, self.invalid, self.more_invalid]
+        output, exit_code = self.call_main(FILENAME=files)
+        self.assertEquals(50, len(output))
+        self.assertEquals(exit_code, 2)
+
+    def test_invalid_disable(self):
+        output, exit_code = self.call_main(**{'--disable': 'foobar'})
+        self.assertEquals(exit_code, 1)
 
 
 class TestHTML5LinterUtils(unittest.TestCase):


### PR DESCRIPTION
This adds the ability to give the `html_lint.py` command multiple input files instead of a single file, e.g.:

```
$ ls test/data
invalid.html  more_invalid.html  valid.html

$ html_lint.py test/data/invalid.html test/data/more_invalid.html
<lots of errors>
```
