### PR TITLE
Add printfilename option

### DIFF
--- a/html_linter.py
+++ b/html_linter.py
@@ -1074,6 +1074,7 @@ def main(options):
     if sys.version_info[0] < 3:
         sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
+    print_filename = options.get('--printfilename')
     disable_str = options.get('--disable') or ''
     disable = disable_str.split(',')
 
@@ -1093,6 +1094,8 @@ def main(options):
         clean_html = template_remover.clean(io.open(filename).read())
         result = lint(clean_html, exclude=exclude)
         if result:
+            if print_filename:
+                result = "{}:{}".format(filename, result)
             print(result)
             results = True
 

--- a/scripts/html_lint.py
+++ b/scripts/html_lint.py
@@ -25,7 +25,7 @@ https://github.com/kangax/html-minifier.
 This software is released under the Apache License. Copyright Deezer 2014.
 
 Usage:
-  html5_lint.py [--disable=DISABLE] FILENAME...
+  html5_lint.py [--disable=DISABLE] [--printfilename] FILENAME...
   html5_lint.py (-h | --help)
   html5_lint.py --version
 
@@ -39,6 +39,7 @@ Options:
                    capitalization, quotation, indentation, formatting,
                    boolean_attribute, invalid_attribute, void_zero,
                    invalid_handler, http_equiv, extra_whitespace.
+  --printfilename  Include the filename when printing the results
 
 """
 

--- a/test/test_html_linter.py
+++ b/test/test_html_linter.py
@@ -606,6 +606,14 @@ class TestHTML5LinterMain(unittest.TestCase):
         output, exit_code = self.call_main(**{'--disable': 'foobar'})
         self.assertEquals(exit_code, 1)
 
+    def test_printfilename(self):
+        files = [self.more_invalid]
+        output, exit_code = self.call_main(
+            **{'FILENAME': files, '--printfilename': True})
+        self.assertEquals(1, len(output))
+        self.assertTrue(self.more_invalid in output[0])
+        self.assertEquals(exit_code, 2)
+
 
 class TestHTML5LinterUtils(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
This PR adds the `printfilename` flag, which includes the filename which produced the error in the resulting error message (a la https://www.gnu.org/prep/standards/html_node/Errors.html)

This is useful when using html-linter with multiple input files. 

For example:

``` console
$ html_lint.py --printfilename test/data/more_invalid.html
test/data/more_invalid.html:2:4: Error: Document Type: Do not close void elements: Remove the trailing "/" from the br tag.
```
