### PR TITLE
Add TeamCity inspection formatting

### DIFF
--- a/html_linter.py
+++ b/html_linter.py
@@ -63,7 +63,10 @@ class UnicodeMixin(object):
 
 
 def teamcity_escape(text):
-    return str(text).replace('|', '||').replace('\'', '|\'')
+    if type(text) is tuple:
+        text = ''.join(text)
+
+    return text.replace('|', '||').replace('\'', '|\'')
 
 
 # pylint: disable=too-few-public-methods,missing-docstring

--- a/test/test_html_linter.py
+++ b/test/test_html_linter.py
@@ -615,6 +615,44 @@ class TestHTML5LinterMain(unittest.TestCase):
         self.assertEquals(exit_code, 2)
 
 
+class TestHTML5LinterMainTeamcity(TestHTML5LinterMain):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['TEAMCITY_PROJECT_NAME'] = 'tests'
+
+        super(TestHTML5LinterMainTeamcity, cls).setUpClass()
+
+    def test_invalid(self):
+        files = [self.invalid]
+        output, exit_code = self.call_main(FILENAME=files)
+        self.assertEquals(2 * 49, len(output))
+        self.assertEquals(exit_code, 2)
+
+    def test_multiple(self):
+        files = [self.valid, self.invalid, self.more_invalid]
+        output, exit_code = self.call_main(FILENAME=files)
+        self.assertEquals(2 * 50, len(output))
+        self.assertEquals(exit_code, 2)
+
+    def test_printfilename(self):
+        files = [self.more_invalid]
+        output, exit_code = self.call_main(
+            **{'FILENAME': files, '--printfilename': True})
+        self.assertEquals(2 * 1, len(output))
+        self.assertTrue(self.more_invalid in output[1])
+        self.assertEquals(exit_code, 2)
+
+    def test_no_printfilename(self):
+        files = [self.more_invalid]
+        # In TeamCity output the filename should be present
+        # regardless of the --printfilename option
+        output, exit_code = self.call_main(
+            **{'FILENAME': files, '--printfilename': False})
+        self.assertEquals(2 * 1, len(output))
+        self.assertTrue(self.more_invalid in output[1])
+        self.assertEquals(exit_code, 2)
+
+
 class TestHTML5LinterUtils(unittest.TestCase):
     @staticmethod
     def get_linter(last_data, last_data_position):


### PR DESCRIPTION
This detects if the tool is being called from within TeamCity, and if so, formats the results as inspection messages for TC to pick up. 

- https://confluence.jetbrains.com/display/TCD10/Working+with+Build+Results#WorkingwithBuildResults-codeInspectionsTab
- https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-inspectionsReportingInspections

Note that I've also refactored the `--printfilename` option since this felt more consistent now that there are more formatting options.

I've tested this version in our TC environment (Python 3.5 and 3.6), but haven't done any checks with Python 2.