### PR TITLE
Add recursive option to lint whole directory

### DIFF
--- a/html_linter.py
+++ b/html_linter.py
@@ -41,6 +41,7 @@ import io
 import os
 import re
 import sys
+import fnmatch
 
 import template_remover
 
@@ -1087,7 +1088,15 @@ def main(options):
 
     exclude = [_DISABLE_MAP[d] for d in disable if d in _DISABLE_MAP]
 
-    filenames = options.get('FILENAME', [])
+    filenames = []
+    
+    if options.get('--recursive'):
+        directory = options.get('DIRECTORY')
+        for root, dirnames, names in os.walk(directory):
+            filenames.extend([os.path.join(root, name) \
+                for name in names if name.endswith('.html')])
+    else:
+        filenames = options.get('FILENAME', [])
 
     results = False
     for filename in filenames:

--- a/scripts/html_lint.py
+++ b/scripts/html_lint.py
@@ -26,6 +26,7 @@ This software is released under the Apache License. Copyright Deezer 2014.
 
 Usage:
   html5_lint.py [--disable=DISABLE] [--printfilename] FILENAME...
+  html5_lint.py [--disable=DISABLE] [--printfilename] [-r | --recursive] DIRECTORY
   html5_lint.py (-h | --help)
   html5_lint.py --version
 
@@ -40,6 +41,7 @@ Options:
                    boolean_attribute, invalid_attribute, void_zero,
                    invalid_handler, http_equiv, extra_whitespace.
   --printfilename  Include the filename when printing the results
+  -r --recursive   Specify a directory to lint .html files.
 
 """
 


### PR DESCRIPTION
Adds `-r | --recursive` option to recursively search for and lint .hmtl files. This allows a whole project to easily be linted.

_Note: Used os.walk to maintain support for python 2._